### PR TITLE
Introduce rspec tag "slow" that is excluded from a standard spec run. Fo...

### DIFF
--- a/spec/features/talks_spec.rb
+++ b/spec/features/talks_spec.rb
@@ -15,7 +15,7 @@ describe "Talks" do
     #     ActiveRecord::RecordNotFound:
     #       ActiveRecord::RecordNotFound
     #
-    it "can be shared to social networks and saves statistics", driver: :chrome do
+    it "can be shared to social networks and saves statistics", driver: :chrome, slow: true do
       pending "S O M E T I M E S   F A I L I N G   S P E C"
       SocialShare.count.should eq(0)
       visit venue_talk_path 'en', @venue, @talk

--- a/spec/features/venues_spec.rb
+++ b/spec/features/venues_spec.rb
@@ -10,14 +10,14 @@ describe "Venues" do
     @user = FactoryGirl.create(:user)
     login_user(@user)
   end
-  
+
   describe "GET venues" do
     it "renders index" do
       visit venues_path
       page.should have_selector(".venues-index")
     end
   end
-  
+
   describe "GET a specific venue" do
     before do
       @venue = FactoryGirl.create(:venue, user: @user)
@@ -47,18 +47,18 @@ describe "Venues" do
           find('a')['href'].should =~ pat
         end
       end
-      
-      it "can be shared to social networks and saves statistics", driver: :chrome do
+
+      it "can be shared to social networks and saves statistics", driver: :chrome, slow: true do
         SocialShare.count.should eq(0)
         visit venue_path(id: @venue)
         page.execute_script('$("#social_share .facebook").click()')
         sleep 0.2
-        
+
         share_window = page.driver.browser.window_handles.last
         page.within_window share_window do
           current_url.should match(/facebook.com/)
         end
-        
+
         SocialShare.count.should eq(1)
       end
     end
@@ -78,14 +78,14 @@ describe "Venues" do
       fill_in 'venue_teaser', with: 'some teaser'
       fill_in 'venue_description', with: 'iwannabelikeyou'
       fill_in 'venue_tag_list', with: 'a,b,c'
-      
+
       fill_in 'venue_talks_attributes_0_title', with: 'some talk title'
       fill_in 'venue_talks_attributes_0_teaser', with: 'some talk teaser'
       fill_in 'venue_talks_attributes_0_starts_at', with: 1.day.from_now
       select '60', from: 'venue_talks_attributes_0_duration'
       fill_in 'venue_talks_attributes_0_tag_list', with: 'd,e,f'
       fill_in 'venue_talks_attributes_0_description', with: 'some talk description'
-      
+
       click_button 'Save'
       page.should have_selector('.venues-show')
       page.should have_content('schubidubi')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,14 @@ ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 RSpec.configure do |config|
 
+  # Use rspec tags to filter for specific specs
+  # Examples
+  #   * Run all specs except for chromedriver: zeus rspec --tag ~driver:chrome spec
+  #   * Run specs with chromedriver: zeus rspec --tag @driver:chrome spec
+  # By default do not run slow specs locally, unless explicitly requested by:
+  #  zeus rspec --tag @slow:true spec
+  config.filter_run_excluding :slow => :true unless ENV['CI']
+
   config.filter_run_excluding file_upload: true if ENV['JS_DRIVER'] == 'phantomjs'
 
   config.color_enabled = true


### PR DESCRIPTION
Introduce rspec tag "slow" that is excluded from a standard spec run. For now
only Selenium based tests are tagged as "slow".
- If you want to run all specs, use: zeus rspec --tag @slow:true spec
