### PR TITLE
postprocessing deletes wave files

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -292,7 +292,7 @@ class Talk < ActiveRecord::Base
     end
     # save recording
     update_attribute :recording, Time.now.strftime(ARCHIVE_STRUCTURE) + "/#{id}"
-    # delete some files (mainly wave files, we'll, keep only flv
+    # delete some files (mainly wave files, we'll keep only flv
     # and compressed files)
     FileUtils.rm(Dir.glob("#{base}/t#{id}-u*.wav")
     FileUtils.rm(Dir.glob("#{base}/#{id}-*.wav")


### PR DESCRIPTION
Wave files are just intermediary formats, we do not need to store them.

When deploying this commit, also run this on the host

```
rm app/shared/archive/*/*/*/*.wav
rm app/shared/archive_raw/*/*/*/*.wav
```
