### PR TITLE
disable angular debug output via settings

### DIFF
--- a/app/assets/javascripts/livepage.js.coffee.erb
+++ b/app/assets/javascripts/livepage.js.coffee.erb
@@ -6,6 +6,11 @@
 
 window.Livepage = angular.module 'Livepage', []
 
+configFunc = ($logProvider) ->
+  $logProvider.debugEnabled <%= !Settings.disable_js_debugging %>
+
+configFunc.$inject = ['$logProvider']
+window.Livepage.config configFunc
 
 # Override Angular exception handler to receive a backtrace in Angular
 # exceptions

--- a/app/views/talks/_config.html.haml
+++ b/app/views/talks/_config.html.haml
@@ -1,8 +1,6 @@
 -# Since angular's dependency injection decides in what order to
 -# resolve dependencies this can totally go into the html page
 -# rendered by rails.
--#
--# TODO remove `pretty` for production
 %script
   Livepage.factory("config", function() {
   return #{ @talk.config_for(current_user).html_safe };


### PR DESCRIPTION
Works great with

```
app@voicerepublic-production:~$ grep debug app/shared/config/settings.local.yml 
disable_js_debugging: true
```

Staging still has debugging enabled.
