### PR TITLE
deliver Blackbox.swf via asset pipeline

### DIFF
--- a/app/assets/flash/Blackbox.swf
+++ b/app/assets/flash/Blackbox.swf
@@ -1,0 +1,1 @@
+../../../lib/flash/Blackbox.swf

--- a/app/assets/javascripts/angular/services/blackbox.js.coffee.erb
+++ b/app/assets/javascripts/angular/services/blackbox.js.coffee.erb
@@ -53,7 +53,7 @@ blackboxFunc = ($log, $window, $q) ->
   $log.debug 'Initializing BlackboxService...'
   margin = 0
 
-  swfobject.embedSWF "/flash/Blackbox.swf", "flashContent",
+  swfobject.embedSWF "<%= asset_path 'Blackbox.swf' %>", "flashContent",
     215 + margin, 140 + margin,
     version, null, flashVars, params, attributes
 

--- a/public/flash
+++ b/public/flash
@@ -1,1 +1,0 @@
-../lib/flash


### PR DESCRIPTION
It works for development. If it works for production can only be tested in production.
