### PR TITLE
change mp3 encoder from avconc to lame

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -148,7 +148,7 @@ Configured portfilter (Nico)
 Installed missing package
 -------------------------
 
-    # apt-get install vorbis-tools
+    # apt-get install vorbis-tools lame
 
 Installed package
 -----------------

--- a/lib/audio/strategy/mp3.rb
+++ b/lib/audio/strategy/mp3.rb
@@ -3,11 +3,11 @@
 module Audio
   module Strategy
     class Mp3 < Base
-      
+
       def input
         "#{name}.wav"
       end
-      
+
       def run
         convert_wav_to_mp3
         output
@@ -15,7 +15,7 @@ module Audio
 
       def convert_wav_to_mp3_cmd
         # "avconv -v quiet -y -i #{input} -b:a 64k -strict experimental #{output}"
-        "avconv -v quiet -y -i #{input} #{output}"
+        "lame --quiet #{input} #{output}"
       end
 
       def output


### PR DESCRIPTION
We have talks that cannot be completely played. Testing has shown that the mp3 files cannot be played by FF.

Reencoding the initial file with lame, however, has proven successfull in a small test.

DEPLOYMENT Information:
- apt-get install lame needs to be done manually
- If PR is accepted we need to include lame in cdist
- We need to re-encode all mp3 files
