### PR TITLE
browser re(p)l

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ Note: As soon as the stream goes live, your client will subscribe a
 2nd time and you will here an echo.
 
 
-Console Cheat Sheet
--------------------
+Rails Console Cheat Sheet
+-------------------------
 
 ### Feature three randomly selected talks since yesterday
 
@@ -356,3 +356,19 @@ Console Cheat Sheet
 ### Manually asses talks
 
     puts *Talk.where("uri like 'lt%'").order(:id).map { |t| '% 4s % 5s % 5s %s' % [t.id, t.storage.values.select { |f| f[:ext]=='.flv' }.inject(0) {|r,s| r + s[:seconds].to_i }, t.recording_override?, t.teaser ] }
+
+### RE(P)L into remote brwoser session
+
+Value of `exec` has to be native JavaScript and will be evaluated in
+the scope of instance of Angular's `session` service.
+
+At this point the P in REPL is still missing.
+
+#### Log on error to the console
+
+    PrivatePub.publish_to '/t981/u1', { exec: '$log.error("hello")' }
+
+#### Force a reload of the page
+
+    PrivatePub.publish_to '/t981/u1', { exec: 'window.location.reload()' }
+

--- a/app/assets/javascripts/angular/services/private_pub.js.coffee
+++ b/app/assets/javascripts/angular/services/private_pub.js.coffee
@@ -12,9 +12,12 @@ privatePubFunc = ($log, $q, config) ->
   fayeExtension =
     outgoing: (message, callback) ->
       if message.channel == "/meta/subscribe"
+        channel = message.subscription
+        subscription = config.subscriptions[channel]
+        $log.error "no subscription for #{channel}" unless subscription?
         message.ext ||= {}
-        message.ext.private_pub_signature = config.subscription.signature
-        message.ext.private_pub_timestamp = config.subscription.timestamp
+        message.ext.private_pub_signature = subscription.signature
+        message.ext.private_pub_timestamp = subscription.timestamp
       callback message
 
   $log.debug 'Loading Faye client...'

--- a/app/assets/javascripts/angular/services/session.js.coffee
+++ b/app/assets/javascripts/angular/services/session.js.coffee
@@ -220,10 +220,13 @@ sessionFunc = ($log, privatePub, util, $rootScope, $timeout, upstream,
   listeners = ->
     (user for id, user of users when user.role == 'listener')
 
+  replHandler = (msg) ->
+    eval msg.data.exec if msg.data.exec?
+
   # TODO idealy this should move into callback: on/Registering$/
   # subscribe to push notifications
-  privatePub.subscribe "/#{config.namespace}/public", pushMsgHandler
-  # privatePub.subscribe "/#{config.namespace}/u#{config.user.id}", pushMsgHandler
+  privatePub.subscribe config.talk.channel, pushMsgHandler
+  privatePub.subscribe config.user.channel, replHandler
 
   # exposed objects
   {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,7 +112,8 @@ class User < ActiveRecord::Base
       name: name,
       role: role_for(talk),
       image: avatar.thumb('100x100#nw').url,
-      stream: "t#{talk.id}-u#{id}"
+      stream: "t#{talk.id}-u#{id}",
+      channel: "/t#{talk.id}/u#{id}"
     }
   end
 

--- a/lib/livepage_config.rb
+++ b/lib/livepage_config.rb
@@ -25,14 +25,15 @@ class LivepageConfig < Struct.new(:talk, :user)
         starts_in: talk.starts_in,
         ends_in: talk.ends_in,
         links: talk.media_links,
-        duration: talk.duration.minutes
+        duration: talk.duration.minutes,
+        channel: talk.public_channel
       },
       starts_at: talk.starts_at.to_i,
       ends_at: talk.ends_at.to_i,
       # faye
       fayeClientUrl: PrivatePub.config[:server] + '/client.js',
       fayeUrl: PrivatePub.config[:server],
-      subscription: subscription,
+      subscriptions: subscriptions,
       # streams
       namespace: "t#{talk.id}",
       # misc
@@ -80,8 +81,13 @@ class LivepageConfig < Struct.new(:talk, :user)
     end
   end
 
-  def subscription
-    PrivatePub.subscription channel: talk.public_channel
+  def subscriptions
+    channels = [ talk.public_channel, 
+                 user_details[:channel] ]
+
+    channels.inject({}) do |r, c|
+      r.merge c => PrivatePub.subscription(channel: c)
+    end
   end
 
   def statemachine_spec


### PR DESCRIPTION
- make LivepageConfig and PrivatePubService aware of multiple subscriptions
- introduce a private namespace (user channel)
- unify source of public namespace (talk channel)
- introduce error message when subscribing to unauthorized channel
- add basic replHandler which listens to the private channel
- update README with example on how to use the private channel
