### PR TITLE
add developper script to start daemons in tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,8 @@ Run App
 
 ### voicerepublic_dev
 
-* `zeus start`
-* `zeus server`
-* `rackup -E production private_pub.ru`
-* `zeus rake rtmp:start`
-* `bundle exec lib/rtmp_watcher.rb run`
+* sudo apt-get install tmux
+* bin/start_everything_in_tmux
 
 ### voicerepublic_backoffice
 

--- a/bin/start_everything_in_tmux
+++ b/bin/start_everything_in_tmux
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if ! tmux -V; then
+  echo "Oh well, you need to install 'tmux' first I'm afraid"
+  exit 1
+fi
+if [ ! -f Gemfile ]; then
+  echo "Sorry, you need to run this from the root rails application directory"
+  exit 1
+fi
+
+tmux new-session -d -s vr_daemons
+
+tmux new-window   -t vr_daemons       'zeus start'
+echo "starting zeus...please be a bit patient"; sleep 5
+tmux split-window -t vr_daemons       'zeus server'
+# we need all these "even-vertical" layout commands below, otherwise tmux is
+# unable to split the current window, because it is too small
+tmux select-layout even-vertical      
+tmux split-window -t vr_daemons       'rackup -E production private_pub.ru'
+tmux select-layout even-vertical      
+
+# The following command would nginx in the background and terminates
+# returning something like:
+#    rtmpd started with pids 20065, 20066
+nginx_pid=$( zeus rake rtmp:start | sed -r 's/.*pids ([0-9]*).*/\1/' )
+
+tmux split-window -t vr_daemons       'bundle exec lib/rtmp_watcher.rb run'
+tmux select-layout even-vertical      
+tmux split-window -t vr_daemons \
+  'sh -c "echo Hi, you are inside tmux. Change panes with CTRL-b arrow"; sleep 99999999'
+tmux select-layout even-vertical
+
+tmux -2 attach-session -t vr_daemons
+kill $nginx_pid


### PR DESCRIPTION
Please pull. The script starts all the necessary daemons for the VR app for the developper and saves screen/terminal space by running everything in a multiplexed terminal. Look:

![Screenshot](http://tpo.sourcepole.ch/opaque/start_everything_inside_tmux.png)
