### PR TITLE
add google webmaster tools verification file

### DIFF
--- a/public/googleffa0c683c7cee3a5.html
+++ b/public/googleffa0c683c7cee3a5.html
@@ -1,0 +1,1 @@
+google-site-verification: googleffa0c683c7cee3a5.html


### PR DESCRIPTION
This is needed to verify voicerepublic.com against the Google Webmaster Tools. I have authenticated the domain 150d ago, but in the meantime we must have lost the authentication file so our domain wasn't belonging to us according to Google anymore(;
