### PR TITLE
affilitation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'coffee-rails' #, '~> 3.2.1'
 gem 'therubyracer', :platforms => :ruby
 gem 'uglifier'#, '>= 1.0.3'
 
+gem 'rack-affiliates'
 gem 'airbrake'
 gem 'rails_config'
 gem 'foundation-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,8 @@ GEM
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     rack (1.5.2)
+    rack-affiliates (0.4.0)
+      rack
     rack-cache (1.2)
       rack (>= 0.4)
     rack-contrib (1.1.0)
@@ -506,6 +508,7 @@ DEPENDENCIES
   poltergeist
   private_pub
   pry-rails
+  rack-affiliates
   rack-cache
   rails (= 4.0.2)
   rails-i18n

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,9 +2,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def new
     resource = build_resource(user_params)
+
+    affiliate = [ request.env['affiliate.tag'],
+                  request.env['affiliate.time'],
+                  request.env['affiliate.from'] ].compact * '|'
+    affiliate = nil if affiliate.blank?
+    resource.referrer = affiliate
+
     respond_with resource
   end
 
+  # CHECK this is propably never used
   def create
     @guest_user = session[:guest_user_id] = nil
     super

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,8 @@ class UsersController < BaseController
                       :about,
                       :password,
                       :password_confirmation,
-                      :conference ]
+                      :conference,
+                      :referrer ]
 
   before_filter :authenticate_user!, :only => [:edit,:update,:destroy]
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,6 +1,7 @@
 = simple_form_for( resource,
                    as: resource_name,
                    url: registration_path(resource_name) ) do |f|
+  = f.input :referrer, as: :hidden
   .input-block
     .form-content-block.row
       .medium-10.medium-centered.columns

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,8 @@ module VoiceRepublic
     # increases Talk#play_count and redirects to Talk#generate_ephemeral_path!
     config.middleware.use 'MediaTracker'
 
+    config.middleware.use 'Rack::Affiliates'
+
     # attribute_protected/attr_accessible lock down
     config.active_record.whitelist_attributes = true
 

--- a/db/migrate/20150305153328_add_referrer_to_users.rb
+++ b/db/migrate/20150305153328_add_referrer_to_users.rb
@@ -1,0 +1,5 @@
+class AddReferrerToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :referrer, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150219152328) do
+ActiveRecord::Schema.define(version: 20150305153328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,21 @@ ActiveRecord::Schema.define(version: 20150219152328) do
 
   add_index "pg_search_documents", ["content"], name: "index_pg_search_documents_on_content", using: :btree
 
+  create_table "purchases", force: true do |t|
+    t.integer  "quantity",         default: 1
+    t.integer  "amount"
+    t.datetime "purchased_at"
+    t.string   "ip"
+    t.string   "express_token"
+    t.string   "express_payer_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.text     "details"
+    t.integer  "owner_id"
+    t.string   "product"
+    t.decimal  "total"
+  end
+
   create_table "reminders", force: true do |t|
     t.integer  "user_id"
     t.integer  "rememberable_id"
@@ -216,12 +231,27 @@ ActiveRecord::Schema.define(version: 20150219152328) do
     t.string   "user_override_uuid"
     t.float    "popularity",         default: 1.0
     t.float    "penalty",            default: 1.0
+    t.boolean  "dryrun",             default: false
   end
 
   add_index "talks", ["grade"], name: "index_talks_on_grade", using: :btree
   add_index "talks", ["popularity"], name: "index_talks_on_popularity", using: :btree
   add_index "talks", ["slug"], name: "index_talks_on_slug", unique: true, using: :btree
   add_index "talks", ["uri"], name: "index_talks_on_uri", using: :btree
+
+  create_table "transactions", force: true do |t|
+    t.string   "type"
+    t.string   "state"
+    t.text     "details"
+    t.integer  "source_id"
+    t.string   "source_type"
+    t.datetime "failed_at"
+    t.datetime "processed_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "transactions", ["source_id", "source_type"], name: "index_transactions_on_source_id_and_source_type", using: :btree
 
   create_table "users", force: true do |t|
     t.string   "firstname"
@@ -257,11 +287,15 @@ ActiveRecord::Schema.define(version: 20150219152328) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
+    t.integer  "credits",                default: 0
+    t.integer  "purchases_count",        default: 0
+    t.string   "referrer"
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", using: :btree
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["purchases_count"], name: "index_users_on_purchases_count", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["slug"], name: "index_users_on_slug", unique: true, using: :btree
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -198,6 +198,19 @@ feature "User can register" do
     page.should have_content "I accept the Terms of Use"
   end
 
+  scenario "Has been referred" do
+    visit root_path ref: 'ABC123'
+    page.click_link('Sign Up')
+    page.fill_in('user_firstname', :with => "Jim")
+    page.fill_in('user_lastname', :with => "Beam")
+    page.fill_in('user_email', with: "jim@example.com")
+    page.fill_in('user_password', :with => "foobar")
+    page.fill_in('user_password_confirmation', :with => "foobar")
+    page.check('user_accept_terms_of_use')
+    page.find('.button-signup').click
+    User.last.referrer.should match(/\AABC123/)
+  end
+
 end
 
 private


### PR DESCRIPTION
:speak_no_evil: 
- Every route now accepts "ref=some_affiliation_tag".
- The affiliation tag is stored in a cookie for 30 days.
- If the user performs a signup during that period, the affiliation tag is stored as the `referrer` on the user.
- The affiliation tag can be chosen freely.
- The affiliation tag will be overwritten by subsequent requests.
