### PR TITLE
move embed to top

### DIFF
--- a/app/views/talks/show.html.haml
+++ b/app/views/talks/show.html.haml
@@ -39,8 +39,7 @@
           .bc-delimiter >
 
           .links-box
-            %a(class          = 'button-embed'
-               data-reveal-id = "modal-embed"
+            %a(data-reveal-id = "modal-embed"
                data-ga-event  = "click talk embedtop talk:#{@talk.id}")
               %span.icon-code{ title: t('.embed_player') }
             #modal-embed.reveal-modal.text-center(data-reveal)


### PR DESCRIPTION
![move-embed](https://cloud.githubusercontent.com/assets/20964/8821480/4131cb4c-305e-11e5-989b-7d895a4eebd8.png)

And podcast will have to go soonish, too. Hence, no more distracting turquoise buttons.
