### PR TITLE
no dryrun talks on lp & explore

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -1,7 +1,7 @@
 class ExploreController < ApplicationController
 
   def index
-    @talks_live     = Talk.live.limit(5)
+    @talks_live     = Talk.publicly_live.limit(5)
     @talks_featured = Talk.featured.limit(5)
     @talks_recent   = Talk.recent.limit(5)
     @talks_popular  = Talk.popular.limit(5)
@@ -9,13 +9,13 @@ class ExploreController < ApplicationController
 
   # GET /explore/featured
   def featured
-    @talks = Talk.prelive.featured.paginate(page: params[:page], per_page: 25)
+    @talks = Talk.featured.prelive.paginate(page: params[:page], per_page: 25)
     render :index
   end
 
   # GET /explore/upcoming
   def upcoming
-    @talks = Talk.prelive.ordered.paginate(page: params[:page], per_page: 25)
+    @talks = Talk.publicly_prelive.ordered.paginate(page: params[:page], per_page: 25)
     render :index
   end
 
@@ -26,7 +26,8 @@ class ExploreController < ApplicationController
       format.html do
         render :index
       end
-      # hack to provide dibran with an easy interface, TODO move to api
+      # TODO check with dibran if this is needed anymore
+      # hack to provide mobile with an easy interface, TODO move to api
       format.json do
         render json: @talks.to_json(only: %w(id slug state title
                                              teaser starts_at ends_at))
@@ -36,7 +37,7 @@ class ExploreController < ApplicationController
 
   # GET /explore/live
   def live
-    @talks = Talk.live.paginate(page: params[:page], per_page: 25)
+    @talks = Talk.publicly_live.paginate(page: params[:page], per_page: 25)
     render :index
   end
 

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -3,7 +3,7 @@ class LandingPageController < BaseController
   def index
     respond_to do |format|
       format.html do
-        @talks_live     = Talk.live
+        @talks_live     = Talk.publicly_live
 
         @talks_featured = Talk.featured.limit(6)
         @talks_recent  	= Talk.recent.limit(6)

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -164,6 +164,9 @@ class Talk < ActiveRecord::Base
 
   scope :nodryrun, -> { where(dryrun: false) }
 
+  scope :publicly_live, -> { nodryrun.live }
+  scope :publicly_prelive, -> { nodryrun.prelive }
+
   scope :featured, -> do
     nodryrun.prelive.
       where("featured_from < ?", Time.zone.now).

--- a/spec/controllers/landing_page_controller_spec.rb
+++ b/spec/controllers/landing_page_controller_spec.rb
@@ -12,6 +12,15 @@ describe LandingPageController do
       get 'index', format: 'rss'
       expect(response).to be_success
     end
+
+    it 'should not show dryrun talks among live' do
+      public_talk = FactoryGirl.create(:talk, state: 'live')
+      private_talk = FactoryGirl.create(:talk, dryrun: true, state: 'live')
+      get :index
+      talks_live = assigns(:talks_live)
+      expect(talks_live).to include(public_talk)
+      expect(talks_live).not_to include(private_talk)
+    end
   end
-  
+
 end


### PR DESCRIPTION
Our statemachine on talks automatically generate scopes. Scope `live` includes all talks in state `live`. But scope `live` also includes test talks (where dryrun is set to true). Hence I introduce two new scopes
- `publicly_live`
- `publicly_prelive`

These scope should be used on prolific controllers like landing page & explore, to make sure test talks do not show up on the respective pages.
