### PR TITLE
monit: add new rabbitmq-server binary

### DIFF
--- a/config/monit.conf
+++ b/config/monit.conf
@@ -1,6 +1,6 @@
 check process rails matching "unicorn master"
 
-check process rabbitmq matching "rabbitmq-server"
+check process rabbitmq matching "beam.smp"
 
 check process faye pidfile /home/app/app/shared/pids/faye.pid
   start = "/home/app/app/current/bin/init/faye start"


### PR DESCRIPTION
 I recognised after I woke up on the morning that we should leave for the retreat that the servers was down. So I checked on Monit and found red spots rabbitmq and bumpy-bridge.

For whatever reason rabbitmq changed their binary. It seems they did. I'm running out of time here. So not to confuse Nick, I patched this into Staging and Live and have deployed already. Kind of hoping thats the right thing to do. however I also do not seem any possible harm.
