### PR TITLE
fix api talk fields

### DIFF
--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -5,6 +5,7 @@ class Api::TalksController < Api::BaseController
   MAX_LIMIT = 20
 
   JSON_CONFIG = {
+    # TODO `only` is generally better than `except`, to not leak data
     except: %w( session
                 storage
                 image_uid
@@ -13,7 +14,12 @@ class Api::TalksController < Api::BaseController
                 penalty
                 slides_uuid
                 recording_override
-                listeners)
+                listeners
+                social_links
+                dryrun
+                user_override_uuid
+                series_id
+                slides_uid )
   }
 
   before_action :authenticate_user!


### PR DESCRIPTION
Plays nicely with https://github.com/voicerepublic/vr_api_specs/commit/371fd30bd010f860c867d2b2b4dbbc1c5cdd47de

After deploy, rspec messages on #vr_tech should vanish.
