### PR TITLE
Do not render "VR: ..." in podcast titles

### DIFF
--- a/config/locales/en-series.yml
+++ b/config/locales/en-series.yml
@@ -17,9 +17,9 @@ en:
       upload_talk: Upload Talk
       subscribe_to_podcast: Podcast
       podcast:
-        title: "VR: %{title}"
+        title: "%{title}"
         subtitle: "Podcast provided by Voice Republic"
-      feed_title: "VR - %{title}"
+      feed_title: "%{title}"
       redirect_text: |
         Please sign up or login to use this feature.
       login: Login

--- a/config/locales/en-users.yml
+++ b/config/locales/en-users.yml
@@ -88,9 +88,9 @@ en:
           You have %{count} credits left.
       purchase_more_credits: Purchase more credits
       podcast:
-        title: "VR: %{username}"
+        title: "%{username}"
         subtitle: "Podcast provided by Voice Republic"
-      feed_title: "VR - %{username}"
+      feed_title: "%{username}"
       listen_later_feed_title: "VR - Listen Later by %{username}"
       title: "%{username} - Voice Republic"
       edit_profile: Edit Profile


### PR DESCRIPTION
I propose getting rid of the "VR: " title prepending all along.

First of all, I do not believe that many non-paying customers will use us as a podcast hoster. Second of all, I do not believe that we should have a branding in a Podcast title of a paying user. And third and last of all, I do not think that "VR" really conveys our brand when people see it in a completely different context (say iTunes). They might more believe the podcast is about Virtual Reality or whatever other acronym them already fancy.

Hope that blatant implementation by deletion is ok.
