### PR TITLE
Fix Metric "Series created by Users"

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -98,7 +98,7 @@ class Metric < ActiveRecord::Base
     end
 
     def series_nondefault_total # FIXME
-      Series.where('id NOT IN (?)', User.pluck(:default_series_id)).count
+      Series.where.not(id: User.pluck(:default_series_id)).count
     end
 
     def series_top_penalty

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Metric do
+
+  it 'aggregates metrics for Series created by Users' do
+    Metric.snapshot!
+    expect(Series.count).to be(0)
+    expect(Metric.where(key: "series_nondefault_total").last.value).to eq(0)
+
+    # Users have a default series
+    user = FactoryGirl.create :user
+    expect(Series.count).to be(1)
+    # That isn't counted
+    Metric.snapshot!
+    expect(Metric.where(key: "series_nondefault_total").last.value).to eq(0)
+
+    # If the user creates a Series, however, it is counted
+    FactoryGirl.create :series, user: user
+    expect(Series.count).to be(2)
+    Metric.snapshot!
+    expect(Metric.where(key: "series_nondefault_total").last.value).to eq(1)
+  end
+
+end


### PR DESCRIPTION
Note: The original implementation worked just fine on my machine,
however it didn't on the Live system. The new query works, though.
