### PR TITLE
added itunes url in itunes tag

### DIFF
--- a/app/views/shared/_podcast.rss.builder
+++ b/app/views/shared/_podcast.rss.builder
@@ -59,7 +59,7 @@ xml.rss namespaces.merge(version: '2.0') do
              type: 'application/rss+xml',
              href: request.url
 
-    xml.itunes :image, href: @podcast.image_url
+    xml.itunes :image, href: @podcast.image_url || itunes_image_url(@podcast.image)
     xml.itunes :category, text: @podcast.category
     xml.itunes :subtitle, @podcast.subtitle
     xml.itunes :summary do


### PR DESCRIPTION
the itunes image url was generated for the channel url only. the itunes:image href was empty.

i added itunes image url generation (same as in channel url) to the itunes:image tags href. with that itunes accepts the image 😄
