### PR TITLE
Fix/facebook register

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -210,7 +210,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
 
-  config.omniauth :facebook, "1452390208332135", "1d2e6c86455e527602187db7c2fb1021", scope: 'email', image: 'large', info_fields: 'first_name,last_name,link'
+  config.omniauth :facebook, "1452390208332135", "1d2e6c86455e527602187db7c2fb1021", scope: 'email', image: 'large', info_fields: 'email,first_name,last_name,link'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
facebook changed their api in july 2015 (?!), so that now we need to explicitly ask for first_name, last_name and profile link. fortunately, this is trivial when using the omniauth-facebook gem. luckily, the subsequent processing of the returned information does not have to be changed.
