### PR TITLE
Decrease margin to next button

### DIFF
--- a/app/assets/stylesheets/_talk.scss
+++ b/app/assets/stylesheets/_talk.scss
@@ -1355,7 +1355,7 @@ ul.share-links {
 .uploader-container {
     // background: $vr-beige;
     // border: 2px solid $vr-purple;
-    height: 220px;
+    height: 110px;
 }
 
 .slides .progress .meter {


### PR DESCRIPTION
There is only one instance of a .uploader-container in markup (the one where the customer fills in the details of a talk).