### PR TITLE
Hide buttons for instant feedback

### DIFF
--- a/lib/vrng/src/vrng/venues/core.cljs
+++ b/lib/vrng/src/vrng/venues/core.cljs
@@ -201,7 +201,7 @@
 
 (defn venue-message-handler [msg]
   (condp = (:event msg)
-    "snapshot" (do (u/reset-state! (:snapshot msg)) (swap! page-state assoc :hide-start-button false))
+    "snapshot" (u/reset-state! (:snapshot msg))
     "stats" (swap! page-state assoc :stats (:stats msg))
     (prn "Unknown message" msg)))
 
@@ -308,7 +308,7 @@
   false)
 
 (defn end-talk-action [talk]
-  (swap! page-state assoc :hide-stop-button true)
+  (swap! page-state assoc :hide-stop-button true :hide-start-button false)
   (track-event "talk end")
   (PUT (talk-url talk)
        {:format :json


### PR DESCRIPTION
The visibility of the launch button depends on :launched @page-state, I introduced :hide-start-button to hide it depending on :hide-start-button @page-state (just how it is already done with the stop button)

I verified it by using artificial lag on push notifications:

`(defn venue-message-handler [msg]
  (go
    (<! (timeout 5000))
    (condp = (:event msg)
    "snapshot" (u/reset-state! (:snapshot msg))
    "stats" (swap! page-state assoc :stats (:stats msg))
    (prn "Unknown message" msg))))
`