### PR TITLE
Fix meta information for edge cases

### DIFF
--- a/lib/vrng/src/vrng/talks/core.cljs
+++ b/lib/vrng/src/vrng/talks/core.cljs
@@ -256,14 +256,13 @@
   "mapping of internal state to state that is interesting to user"
   [state]
   (cond
-    (= state "prelive") "Planned"
+    (= state "prelive") "Scheduled"
     (= state "live") "Live"
     (= state "archived") "Archived"
   :else "Archiving"))
 
 (defn talk-info-meta-info-comp
   [starts-at started-at state play-count]
-  (prn (or started-at starts-at))
   (let [relative-time (relative-time (or started-at starts-at))]
     [:p {:class "meta-info"}
      [:span (state-label state) " • " relative-time]


### PR DESCRIPTION
This is the new mapping of talk state to meta information:

- talk is live: "now"
- talk is queued/postlive/prelive: time to planned time/time since planned time
- talk is archived and planned time > current time: "Archived - x plays"
- talk is archived and planned time < current time: "time since planned time - x plays"