### PR TITLE
Fix fb login and registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'foundation-rails', '6.2.0.1'
 gem 'jquery-rails'
 gem 'devise', '~> 3.4.0'           # authentication/iam lib for rails
 gem 'simple_token_authentication', github: 'branch14/simple_token_authentication'
-gem 'omniauth-facebook'
+gem 'omniauth-facebook', '4.0.0'
 gem 'omniauth-google-oauth2'
 gem 'friendly_id'                  # make urls more friendly
 gem 'will_paginate'                # pagination-extension to active-record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,7 +429,7 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
-    omniauth-facebook (3.0.0)
+    omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-google-oauth2 (0.3.1)
       jwt (~> 1.0)
@@ -669,7 +669,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.2.0)
   mailgun_rails
   meta_request
-  omniauth-facebook
+  omniauth-facebook (= 4.0.0)
   omniauth-google-oauth2
   pg
   pg_search
@@ -705,4 +705,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.15.1
+   1.15.3


### PR DESCRIPTION
Everything seems to work on our side, apparently fb stopped supporting certain versions of their login API. An update of 'omniauth-facebook' solved the problem with a test app at fb using API v2.10.

Unfortunately I can't test it with the real fb app, since the exact callback url has to be whitelisted/registered. If it doesn't work on staging, we have to ask Alain to pull up the API version in the app dashboard to v2.10.
