### PR TITLE
Fix partially supported `clip-path` property

### DIFF
--- a/lib/vrng/src/vrng/talks/timeline.cljs
+++ b/lib/vrng/src/vrng/talks/timeline.cljs
@@ -23,6 +23,7 @@
   []
   [:div.timeline.jp-seek-bar {:on-click seek-action :style {:width "0%"
                                                             :clip-path "url(#progress)"
+                                                            :-webkit-clip-path "url(#progress)"
                                                             :position "relative"}}
    [:div.track-buffered.jp-play-bar {:style {:width "0%"
                                              :background "#4a4502"}}]


### PR DESCRIPTION
Tested prefixed property, works with a recent version of Safari: https://www.pivotaltracker.com/story/show/151762983/comments/180696111