### PR TITLE
upgrade icebox to stretch

### DIFF
--- a/lib/icebox/Dockerfile
+++ b/lib/icebox/Dockerfile
@@ -34,6 +34,8 @@ RUN apt-get -qq -y install liquidsoap \
 RUN apt-get -qq -y install python-pip && \
     pip install awscli
 
+RUN apt-get -qq -y install procps
+
 RUN apt-get clean
 
 RUN mkdir /share && \


### PR DESCRIPTION
Fixing erosion.

The good thing. The icecast server version remains the same, but backports is not needed anymore. (Still using the backports base image though.)