### PR TITLE
some logging on venue

### DIFF
--- a/lib/vrng/src/vrng/venues/core.cljs
+++ b/lib/vrng/src/vrng/venues/core.cljs
@@ -126,18 +126,9 @@
    (filter #(= (venue-device-id) (:id %))
            (user-owned-devices))))
 
-;; TODO use correct name, noop is not
 (defn device-display-name []
   (or (venue-device-name)
       (:name (selected-device)) "Not Selected"))
-
-;; Messaging
-
-(defn venue-message-handler [msg]
-  (condp = (:event msg)
-    "snapshot" (u/reset-state! (:snapshot msg))
-    "stats" (swap! page-state assoc :stats (:stats msg))
-    (prn "Unknown message" msg)))
 
 (def uniqkey (atom 0))
 
@@ -154,8 +145,29 @@
   [content]
   (swap! page-state update :messages conj
          {:id (random-uuid)
+          :level 0
           :time (.format (js/moment) "x")
           :content (map add-key content)}))
+
+(defn add-debug-message
+  "Adds a message to the message queue which is displayed in the chat
+  window."
+  [content]
+  (swap! page-state update :messages conj
+         {:id (random-uuid)
+          :level 1
+          :time (.format (js/moment) "x")
+          :content (map add-key content)}))
+
+;; Messaging
+
+(defn venue-message-handler [msg]
+  (condp = (:event msg)
+    "snapshot" (do
+                 (add-debug-message (str "received snapshot from " (:now msg)))
+                 (u/reset-state! (:snapshot msg)))
+    "stats" (swap! page-state assoc :stats (:stats msg))
+    (prn "Unknown message" msg)))
 
 ;; Actions
 
@@ -929,7 +941,10 @@
   [:div.clearfix [:a.button.tiny.stage-button {:href (active-talk-url)} [icon "eye"] "View Your Talk"]])
 
 (defn messages []
-  (reverse (sort-by :time (:messages @page-state))))
+  (->> (:messages @page-state)
+       (filter #(<= (:level %) (:message-level @page-state)))
+       (sort-by :time)
+       (reverse)))
 
 (defn vec-if-only-one [x]
   (if (seq? x) x [x]))
@@ -946,12 +961,18 @@
 
     [:span.message-time (.format (js/moment (:time message) "x") "H:mm:ss")]]])
 
+(def max-message-level 2)
+
+(defn cycle-message-level []
+  (.log js/console (:message-level @page-state))
+  (swap! page-state update :message-level #(mod (inc %) max-message-level)))
+
 (defn message-container-comp []
-  [:div#message-container.medium-4.columns.float-right
-   [:h4.section-title.text-center "Messages"]
-   ;;(doall (map server-message-comp (messages)))
-   (for [message (messages)] ^{:key (:id message)} [server-message-comp message])
-   ])
+  (let [deco (into [:span] (repeat (:message-level @page-state) "*"))]
+    [:div#message-container.medium-4.columns.float-right
+     [:h4.section-title.text-center {:on-click cycle-message-level} deco "Messages" deco]
+     (for [message (messages)] ^{:key (:id message)} [server-message-comp message])
+     ]))
 
 ;;logo test
 (defn logo-component []
@@ -1231,7 +1252,9 @@
  (fn [key at0m old new]
    (let [old-state (get-in old [:venue :state])
          new-state (get-in new [:venue :state])]
-     (if (not= old-state new-state)
+     (when (not= old-state new-state)
+       (add-debug-message
+        (str "venue state changed from " old-state " to " new-state))
        (case [old-state new-state]
 
          ["offline" "available"]

--- a/lib/vrng/src/vrng/venues/state.cljs
+++ b/lib/vrng/src/vrng/venues/state.cljs
@@ -5,6 +5,7 @@
 ))
 
 (defonce page-state (atom {:messages []
+                           :message-level 0
                            :autostart false
                            :launched false
                            :instructions true


### PR DESCRIPTION
@munen I'm sorry the UI code is a mess in some parts.

This will log all venue state changes & unix timestamps of incoming snapshots. They will integrate in the timeline on the right if "MESSAGES" is clicked.