### PR TITLE
Do not nest <p> under <p>

### DIFF
--- a/lib/vrng/src/vrng/talks/core.cljs
+++ b/lib/vrng/src/vrng/talks/core.cljs
@@ -261,7 +261,7 @@
 (defn talk-info-comp []
   [:div {:class "row collapse"}
    [:div {:class "medium-7 columns"}
-    [:p.teaser.lead.text-center.medium-text-left (teaser)
+    [:div.teaser.lead.text-center.medium-text-left (teaser)
      (if-not (str/blank? (talk-speakers))
        [:p.speakers.text-center.medium-text-left " Speakers: "
         [:span.names (talk-speakers)]])]]


### PR DESCRIPTION
Makes this error in the console go away: ![selection_072](https://user-images.githubusercontent.com/505721/37241045-37974e86-2453-11e8-982f-ca6a756c4acf.png)

UI still looks the same for me, so there's probably no CSS rule directly going for the `<p>` element before.